### PR TITLE
Minor optimization for Signup and Login process.

### DIFF
--- a/application/controllers/user.php
+++ b/application/controllers/user.php
@@ -73,13 +73,7 @@ class User extends CI_Controller {
                 $err_code = '200';
                 unset($data['passconf']);
                 $this->user->sign_up($data);
-                $token = $this->user->set_token($data['mail']);
-                $link = site_url('user/activate') . '/' . $token;
-                $this->email->from('beidachexie@126.com', '北京大学自行车协会');
-                $this->email->to($data['mail']);
-                $this->email->subject('第十三届全国高校山地车交流赛帐户确认');
-                $this->email->message('请点击以下链接激活帐户' . $link);
-                $this->email->send();
+                $this->email->send_account_confirm_mail($data['mail']);
             }
 
             exit(err_msg($err_code));

--- a/application/controllers/user.php
+++ b/application/controllers/user.php
@@ -14,9 +14,9 @@ class User extends CI_Controller {
     function __construct()
     {
         parent::__construct();
-        $this->load->model('user_model', 'user');
         $this->load->helper(array('form', 'url', 'html', 'lib'));
-        $this->load->library(array('form_validation'));
+        $this->load->library(array('email', 'form_validation', 'session'));
+        $this->load->model('user_model', 'user');
     }
 
     /*
@@ -59,7 +59,6 @@ class User extends CI_Controller {
 
     public function signup() {
         date_default_timezone_set('PRC');
-        $this->load->library(array('email'));
 
         if ($this->input->server('REQUEST_METHOD') == 'GET') {
             $this->load->view('header');

--- a/application/controllers/user.php
+++ b/application/controllers/user.php
@@ -9,14 +9,20 @@
 class User extends CI_Controller {
 
     /*
+     * Contrunction for User Controller.
+     */
+    function __construct()
+    {
+        parent::__construct();
+        $this->load->model('user_model', 'user');
+        $this->load->helper(array('form', 'url', 'html', 'lib'));
+        $this->load->library(array('form_validation'));
+    }
+
+    /*
      * The login page for users.
      */
     public function login() {
-
-        $this->load->helper(array('form', 'url', 'html', 'lib'));
-        $this->load->model('user_model', 'user');
-        $this->load->library('form_validation');
-        $this->load->library('session');
 
         if ($this->input->server('REQUEST_METHOD') == 'GET') {
             $this->load->view('header');
@@ -53,9 +59,7 @@ class User extends CI_Controller {
 
     public function signup() {
         date_default_timezone_set('PRC');
-        $this->load->helper(array('form', 'url', 'html', 'lib'));
-        $this->load->library(array('form_validation', 'email'));
-        $this->load->model('user_model', 'user');
+        $this->load->library(array('email'));
 
         if ($this->input->server('REQUEST_METHOD') == 'GET') {
             $this->load->view('header');

--- a/application/libraries/MY_Email.php
+++ b/application/libraries/MY_Email.php
@@ -52,6 +52,6 @@ class MY_Email extends CI_Email
         $token = $this->ci->user->set_token($mail);
         $link = site_url('user/activate') . '/' . $token;
         $message = '请点击以下链接激活帐户' . $link;
-        $this->send_mail($mail, $subject, $message, $options);
+        $this->send_mail($mail, $subject, $message);
     }
 }

--- a/application/libraries/MY_Email.php
+++ b/application/libraries/MY_Email.php
@@ -1,0 +1,57 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+class MY_Email extends CI_Email
+{
+
+    var $from_mail;
+
+    /*
+     * Contruction function for My_Email.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->ci =& get_instance();
+
+        $this->ci->config->load('email');
+        $this->from_mail = $this->ci->config->item('smtp_user');
+
+        $this->ci->load->helper(array('url'));
+        $this->ci->load->model('user_model', 'user');
+    }
+
+    /*
+     * This is the base function for all mail sending actions.
+     */
+    public function send_mail(
+        $to_mail,
+        $subject,
+        $message,
+        $customOptions = array()
+    ) {
+        $defaultOptions = array(
+            'from_mail' => $this->from_mail,
+            'from_name' => '北京大学自行车协会'
+        );
+        $options = array_merge($defaultOptions, $customOptions);
+        $from_mail = $options['from_mail'];
+        $from_name = $options['from_name'];
+
+        $this->from($from_mail, $from_name);
+        $this->to($to_mail);
+        $this->subject($subject);
+        $this->message($message);
+        $this->send();
+    }
+
+    /*
+     * Send account confirmation email.
+     */
+    public function send_account_confirm_mail($mail) {
+        $subject = '第十三届全国高校山地车交流赛帐户确认';
+        $token = $this->ci->user->set_token($mail);
+        $link = site_url('user/activate') . '/' . $token;
+        $message = '请点击以下链接激活帐户' . $link;
+        $this->send_mail($mail, $subject, $message, $options);
+    }
+}

--- a/application/views/signup_form.php
+++ b/application/views/signup_form.php
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     var controller = "<?=site_url('user/signup')?>";
-    var directto = "<?=base_url()?>";
+    var directto = "<?=site_url('user/login')?>";
 </script>
 <div class="signcontainer">
     <h3>请输入注册信息</h3>

--- a/application/views/signup_form.php
+++ b/application/views/signup_form.php
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     var controller = "<?=site_url('user/signup')?>";
-    var directto = "<?=site_url('user/login')?>";
+    var directto = "<?=base_url()?>";
 </script>
 <div class="signcontainer">
     <h3>请输入注册信息</h3>


### PR DESCRIPTION
- Use `exit(err_msg($err_code))` rather than `echo`.
- Change the logical order of different error type and exit once a more important one occurred.
<del>- Redirect to login page after signup successfully. (This is more reasonable than index page, I think)</del>
- Introduce custom email library to make send emails easier in controller.
- Other minor change, like add an empty line between different code 'sections'.